### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/glowing/package.json
+++ b/glowing/package.json
@@ -31,6 +31,7 @@
     "pm2": "^6.0.8",
     "prettier": "^3.6.2",
     "socket.io": "^4.8.1",
-    "webpack": "^5.100.2"
+    "webpack": "^5.100.2",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/glowing/server.js
+++ b/glowing/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const PORT = 3000;
@@ -30,7 +31,12 @@ app.get('/api/vpn-check', async (req, res) => {
 });
 
 // ✅ Custom 404 page
-app.use((req, res) => {
+const notFoundLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests to non-existent routes, please try again later.' }
+});
+app.use(notFoundLimiter, (req, res) => {
   res.status(404).sendFile(path.join(__dirname, 'public', '404.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/1](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/1)

To address the issue, we will add rate limiting to the custom 404 handler. We will use the `express-rate-limit` package to limit the number of requests to the 404 handler. Specifically, we will configure a rate limiter with a reasonable threshold (e.g., 100 requests per 15 minutes) and apply it to the 404 route. This ensures that excessive requests to non-existent routes do not overwhelm the server.

Steps:
1. Install the `express-rate-limit` package if not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings.
4. Apply the rate limiter middleware to the custom 404 handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
