### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/glowing/package.json
+++ b/glowing/package.json
@@ -32,9 +32,8 @@
     "prettier": "^3.6.2",
     "socket.io": "^4.8.1",
     "webpack": "^5.100.2",
-
     "express-rate-limit": "^8.0.1",
-    "validator": "^13.15.15"
-
+    "validator": "^13.15.15",
+    "request-ip": "^3.3.0"
   }
 }

--- a/glowing/server.js
+++ b/glowing/server.js
@@ -4,7 +4,7 @@ const path = require('path');
 const rateLimit = require('express-rate-limit');
 
 const validator = require('validator');
-
+const requestIp = require('request-ip');
 
 const app = express();
 const PORT = 3000;
@@ -25,7 +25,7 @@ app.use(express.static('public'));
 // ✅ VPN Detector API
 const axios = require('axios');
 app.get('/api/vpn-check', async (req, res) => {
-  const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  const ip = requestIp.getClientIp(req);
   if (!validator.isIP(ip)) {
     return res.status(400).json({ error: 'Invalid IP address' });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/2](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/2)

To fix the SSRF vulnerability, we should ensure that the IP address used in the outgoing request is not directly controlled by the user. The best way to do this is to only allow the server to check the IP address of the actual client connection (`req.connection.remoteAddress`), and ignore the `x-forwarded-for` header, unless you are certain that your server is behind a trusted proxy that sets this header correctly. Alternatively, you can allow-list only trusted proxies and extract the client IP accordingly. For most use cases, especially if you are not behind a proxy, using `req.connection.remoteAddress` is safest.

Additionally, you should continue to validate the IP address using `validator.isIP(ip)`. If you must support proxies, use a trusted library like `request-ip` to safely extract the client IP.

**Changes to make:**
- Replace the extraction of `ip` to use only `req.connection.remoteAddress`, or use a trusted library to extract the real client IP.
- Continue to validate the IP address.
- No changes are needed to the outgoing request, as the IP is now not user-controllable.

**Required imports:**  
If using `request-ip`, add `const requestIp = require('request-ip');` at the top.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
