### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -22,6 +24,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/10](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/10)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. For the `build` job, only read access to repository contents is needed. For the `publish-npm` job, write access to `packages` is required to publish the package. The `permissions` block can be added at the job level to ensure each job has the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
