### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/glowing/server.js
+++ b/glowing/server.js
@@ -162,7 +162,10 @@ app.post('/api/signup', upload.single('avatar'), async (req, res) => {
   let avatar = '';
   if (req.file) {
     const ext = path.extname(req.file.originalname);
-    const newPath = path.join(AVATAR_DIR, req.file.filename + ext);
+    const newPath = path.resolve(AVATAR_DIR, req.file.filename + ext);
+    if (!newPath.startsWith(path.resolve(AVATAR_DIR))) {
+      return res.status(400).json({ error: 'Invalid file path.' });
+    }
     fs.renameSync(req.file.path, newPath);
     avatar = 'avatars/' + path.basename(newPath);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/5](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/5)

To fix the issue, we need to ensure that the constructed file path (`newPath`) is validated and constrained to a safe directory. This can be achieved by:
1. Normalizing the path using `path.resolve` to remove any `..` segments.
2. Verifying that the resolved path starts with the intended root directory (`AVATAR_DIR`).
3. Rejecting the operation if the path is outside the safe directory.

The fix involves modifying the code around line 165-166 to include these validation steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
