### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/glowing/server.js
+++ b/glowing/server.js
@@ -166,7 +166,13 @@ app.post('/api/signup', upload.single('avatar'), async (req, res) => {
     if (!newPath.startsWith(path.resolve(AVATAR_DIR))) {
       return res.status(400).json({ error: 'Invalid file path.' });
     }
-    fs.renameSync(req.file.path, newPath);
+    // Ensure the uploaded file path is within the expected upload directory
+    const uploadDir = path.resolve('uploads'); // Change 'uploads' if your multer dest is different
+    const filePathResolved = path.resolve(req.file.path);
+    if (!filePathResolved.startsWith(uploadDir)) {
+      return res.status(400).json({ error: 'Invalid upload file path.' });
+    }
+    fs.renameSync(filePathResolved, newPath);
     avatar = 'avatars/' + path.basename(newPath);
   }
   const id = genUserId();


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/4](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/4)

To fix the problem, we should ensure that the source path (`req.file.path`) used in `fs.renameSync` is within a safe, expected directory. This can be done by resolving and normalizing the path, then checking that it starts with the expected upload directory. If the check fails, the operation should be aborted and an error returned. This is similar to the check already performed for the destination path (`newPath`). 

Specifically:
- Before calling `fs.renameSync`, resolve `req.file.path` to an absolute path.
- Check that this resolved path starts with the expected upload directory (the same directory multer uses for temporary uploads).
- If the check fails, return an error.
- Only proceed with `fs.renameSync` if both the source and destination paths are within their respective safe directories.

You may need to define the upload directory path (e.g., `UPLOAD_DIR`) if it is not already defined, and ensure it matches the multer configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
