### PR TITLE
Potential fix for code scanning alert no. 12: Clear text transmission of sensitive cookie

### DIFF
--- a/glowing/server.js
+++ b/glowing/server.js
@@ -43,7 +43,7 @@ app.use(session({
   secret: 'your-secret-key',
   resave: false,
   saveUninitialized: true,
-  cookie: { secure: false }
+  cookie: { secure: process.env.NODE_ENV === 'production' }
 }));
 app.use(csrf());
 


### PR DESCRIPTION
Potential fix for [https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/12](https://github.com/glowing-jellyfishing/glowing-jellyfishing.github.io/security/code-scanning/12)

To fix the problem, the session cookie should be configured with the `secure` attribute set to `true`, ensuring it is only sent over HTTPS connections. This is done by changing the session middleware configuration in glowing/server.js, specifically the `cookie` object in the `session` options. For development environments where HTTPS is not used, you can conditionally set `secure: false`, but for production, it must be `true`. The best way to implement this is to set `secure: true` and optionally use an environment variable to allow `secure: false` in development. This change only affects the session middleware configuration and does not alter any other functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
